### PR TITLE
Integrate message signing

### DIFF
--- a/packages/adapter/src/methods.ts
+++ b/packages/adapter/src/methods.ts
@@ -1,4 +1,9 @@
-import {Message, MetamaskFilecoinRpcRequest, SignedMessage, SnapConfig} from "@nodefactory/metamask-filecoin-types";
+import {
+  MetamaskFilecoinRpcRequest,
+  PartialMessage,
+  SignedMessage,
+  SnapConfig
+} from "@nodefactory/metamask-filecoin-types";
 import {MetamaskFilecoinSnap} from "./snap";
 
 async function sendSnapMethod<T>(request: MetamaskFilecoinRpcRequest, snapId: string): Promise<T> {
@@ -30,7 +35,7 @@ export async function configure(this: MetamaskFilecoinSnap, configuration: SnapC
   return await sendSnapMethod({method: "configure", params: {configuration: configuration}}, this.snapId);
 }
 
-export async function signMessage(this: MetamaskFilecoinSnap, message: Message): Promise<SignedMessage> {
+export async function signMessage(this: MetamaskFilecoinSnap, message: PartialMessage): Promise<SignedMessage> {
   return await sendSnapMethod({method: "signMessage", params: {message: message}}, this.snapId);
 }
 

--- a/packages/adapter/src/methods.ts
+++ b/packages/adapter/src/methods.ts
@@ -1,6 +1,5 @@
-import {MetamaskFilecoinRpcRequest, SnapConfig} from "@nodefactory/metamask-filecoin-types";
+import {Message, MetamaskFilecoinRpcRequest, SignedMessage, SnapConfig} from "@nodefactory/metamask-filecoin-types";
 import {MetamaskFilecoinSnap} from "./snap";
-import {Message} from "./types";
 
 async function sendSnapMethod<T>(request: MetamaskFilecoinRpcRequest, snapId: string): Promise<T> {
   return await window.ethereum.send({
@@ -31,6 +30,6 @@ export async function configure(this: MetamaskFilecoinSnap, configuration: SnapC
   return await sendSnapMethod({method: "configure", params: {configuration: configuration}}, this.snapId);
 }
 
-export async function signMessage(this: MetamaskFilecoinSnap, message: Message) {
+export async function signMessage(this: MetamaskFilecoinSnap, message: Message): Promise<SignedMessage> {
   return await sendSnapMethod({method: "signMessage", params: {message: message}}, this.snapId)
 }

--- a/packages/adapter/src/methods.ts
+++ b/packages/adapter/src/methods.ts
@@ -33,3 +33,7 @@ export async function configure(this: MetamaskFilecoinSnap, configuration: SnapC
 export async function signMessage(this: MetamaskFilecoinSnap, message: Message): Promise<SignedMessage> {
   return await sendSnapMethod({method: "signMessage", params: {message: message}}, this.snapId)
 }
+
+export async function signMessageRaw(this: MetamaskFilecoinSnap, rawMessage: string): Promise<string> {
+  return await sendSnapMethod({method: "signMessageRaw", params: {message: rawMessage}}, this.snapId);
+}

--- a/packages/adapter/src/methods.ts
+++ b/packages/adapter/src/methods.ts
@@ -1,5 +1,6 @@
 import {MetamaskFilecoinRpcRequest, SnapConfig} from "@nodefactory/metamask-filecoin-types";
 import {MetamaskFilecoinSnap} from "./snap";
+import {Message} from "./types";
 
 async function sendSnapMethod<T>(request: MetamaskFilecoinRpcRequest, snapId: string): Promise<T> {
   return await window.ethereum.send({
@@ -28,4 +29,8 @@ export async function exportPrivateKey(this: MetamaskFilecoinSnap): Promise<stri
 
 export async function configure(this: MetamaskFilecoinSnap, configuration: SnapConfig): Promise<void> {
   return await sendSnapMethod({method: "configure", params: {configuration: configuration}}, this.snapId);
+}
+
+export async function signMessage(this: MetamaskFilecoinSnap, message: Message) {
+  return await sendSnapMethod({method: "signMessage", params: {message: message}}, this.snapId)
 }

--- a/packages/adapter/src/methods.ts
+++ b/packages/adapter/src/methods.ts
@@ -31,7 +31,7 @@ export async function configure(this: MetamaskFilecoinSnap, configuration: SnapC
 }
 
 export async function signMessage(this: MetamaskFilecoinSnap, message: Message): Promise<SignedMessage> {
-  return await sendSnapMethod({method: "signMessage", params: {message: message}}, this.snapId)
+  return await sendSnapMethod({method: "signMessage", params: {message: message}}, this.snapId);
 }
 
 export async function signMessageRaw(this: MetamaskFilecoinSnap, rawMessage: string): Promise<string> {

--- a/packages/adapter/src/snap.ts
+++ b/packages/adapter/src/snap.ts
@@ -1,5 +1,5 @@
 import {FilecoinSnapApi} from "@nodefactory/metamask-filecoin-types";
-import {configure, exportPrivateKey, getAddress, getBalance, getPublicKey} from "./methods";
+import {configure, exportPrivateKey, getAddress, getBalance, getPublicKey, signMessage} from "./methods";
 
 export class MetamaskFilecoinSnap {
 
@@ -18,7 +18,8 @@ export class MetamaskFilecoinSnap {
       exportPrivateKey: exportPrivateKey.bind(this),
       getAddress: getAddress.bind(this),
       getBalance: getBalance.bind(this),
-      getPublicKey: getPublicKey.bind(this)
+      getPublicKey: getPublicKey.bind(this),
+      signMessage: signMessage.bind(this)
     };
   };
 }

--- a/packages/adapter/src/snap.ts
+++ b/packages/adapter/src/snap.ts
@@ -1,5 +1,13 @@
 import {FilecoinSnapApi} from "@nodefactory/metamask-filecoin-types";
-import {configure, exportPrivateKey, getAddress, getBalance, getPublicKey, signMessage} from "./methods";
+import {
+  configure,
+  exportPrivateKey,
+  getAddress,
+  getBalance,
+  getPublicKey,
+  signMessage,
+  signMessageRaw
+} from "./methods";
 
 export class MetamaskFilecoinSnap {
 
@@ -19,7 +27,8 @@ export class MetamaskFilecoinSnap {
       getAddress: getAddress.bind(this),
       getBalance: getBalance.bind(this),
       getPublicKey: getPublicKey.bind(this),
-      signMessage: signMessage.bind(this)
+      signMessage: signMessage.bind(this),
+      signMessageRaw: signMessageRaw.bind(this)
     };
   };
 }

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -11,3 +11,15 @@ declare global {
     };
   }
 }
+
+// Filecoin message
+export interface Message {
+  to: string;
+  from: string;
+  nonce: number;
+  value: string;
+  gasprice: string
+  gaslimit: number;
+  method: number;
+  params?: any;
+}

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -11,15 +11,3 @@ declare global {
     };
   }
 }
-
-// Filecoin message
-export interface Message {
-  to: string;
-  from: string;
-  nonce: number;
-  value: string;
-  gasprice: string
-  gaslimit: number;
-  method: number;
-  params?: any;
-}

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^16.13.0",
     "react-scripts": "3.4.0",
     "sass": "^1.26.3",
+    "to-hex": "^0.0.15",
     "typescript": "~3.7.2"
   },
   "scripts": {

--- a/packages/example/src/components/SignMessage/SignMessage.tsx
+++ b/packages/example/src/components/SignMessage/SignMessage.tsx
@@ -1,0 +1,71 @@
+import React, {useState} from "react";
+import {Box, Button, Card, CardContent, CardHeader, Dialog, Grid, TextField} from '@material-ui/core/';
+import {DialogActions, DialogContent, DialogContentText, DialogTitle, Typography} from "@material-ui/core";
+import {FilecoinSnapApi} from "@nodefactory/metamask-filecoin-types";
+import toHex from "to-hex";
+
+export interface SignMessageProps {
+    api: FilecoinSnapApi | null
+}
+
+export const SignMessage = (props: SignMessageProps) => {
+    const [textFieldValue, setTextFieldValue] = useState<string>("");
+    const [modalBody, setModalBody] = useState<string>("");
+    const [modalOpen, setModalOpen] = useState<boolean>(false);
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setTextFieldValue(event.target.value);
+      };
+
+    const onSubmit = async () => {
+        if(textFieldValue && props.api) {
+            const rawMessage = toHex(textFieldValue, {addPrefix: true});
+            const signature = await props.api.signMessageRaw(rawMessage);
+            setTextFieldValue("");
+            setModalBody(signature);
+            setModalOpen(true);
+        }
+    };
+
+    return (
+        <Card style={{height: "100%"}}>
+            <CardHeader title="Sign custom message"/>
+            <CardContent>
+                <Grid container>
+                    <TextField 
+                    onChange={handleChange} 
+                    value={textFieldValue} 
+                    size="medium" 
+                    fullWidth 
+                    id="recipient" 
+                    label="Message" 
+                    variant="outlined" 
+                    />
+                </Grid>
+                <Box m="0.5rem" />
+                <Grid container justify="flex-end">
+                    <Button onClick={onSubmit} color="secondary" variant="contained" size="large">Sign</Button>
+                </Grid>
+            </CardContent>
+            <Dialog
+                open={modalOpen}
+                onClose={() => setModalOpen(false)}
+                aria-labelledby="alert-dialog-title"
+                aria-describedby="alert-dialog-description"
+            >
+                <DialogTitle id="alert-dialog-title">{"Message signature"}</DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="alert-dialog-description">
+                        This is signature of your message:<br/>
+                        <Typography style={{ wordWrap: "break-word" }}>{modalBody}</Typography>
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setModalOpen(false)} color="primary" autoFocus>
+                        OK
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Card>
+    );
+}

--- a/packages/example/src/components/Transfer/Transfer.tsx
+++ b/packages/example/src/components/Transfer/Transfer.tsx
@@ -1,0 +1,101 @@
+import React, {useCallback, useState} from "react";
+import {
+    Box,
+    Button,
+    Card,
+    CardContent,
+    CardHeader,
+    Grid,
+    InputAdornment,
+    Snackbar,
+    TextField
+} from '@material-ui/core/';
+import {Alert} from "@material-ui/lab";
+import {FilecoinSnapApi} from "@nodefactory/metamask-filecoin-types";
+
+interface ITransferProps {
+    network: string,
+    api: FilecoinSnapApi | null
+}
+
+type AlertSeverity = "success" | "warning" | "info" | "error";
+
+export const Transfer: React.FC<ITransferProps> = ({network, api}) => {
+    const [recipient, setRecipient] = useState<string>("");
+    const [amount, setAmount] = useState<string | number>("");
+
+    const [alert, setAlert] = useState(false);
+    const [severity, setSeverity] = useState("success" as AlertSeverity);
+    const [message, setMessage] = useState("");
+
+    const handleRecipientChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+        setRecipient(event.target.value);
+    }, [setRecipient]);
+
+    const handleAmountChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+        setAmount(event.target.value);
+    }, [setAmount]);
+
+    const showAlert = (severity: AlertSeverity, message: string) => {
+        setSeverity(severity);
+        setMessage(message);
+        setAlert(true);
+    };
+
+    const onSign = useCallback(async () => {
+        if (amount && recipient && api) {
+            const address = await api.getAddress();
+            // Temporary signature method until sending is implemented
+            const signedMessage = await api.signMessage({
+                from: address,
+                to: recipient,
+                value: BigInt(amount).toString(),
+                method: 1,
+                gaslimit: 100,
+                gasprice: "0",
+                nonce: 1
+            });
+            showAlert("info", `Message signature: ${signedMessage.signature.data}`);
+        }
+    }, [amount, api, recipient]);
+
+    const onSubmit = useCallback(args => {console.log("Transaction submited");}, []);
+
+    return (
+        <Card>
+            <CardContent>
+                <CardHeader title="Transfer"/>
+                <Grid container alignItems="center" justify="space-between">
+                    <Grid item xs={12}>
+                        <TextField
+                        onChange={handleRecipientChange} size="medium" fullWidth id="recipient" label="Recipient" variant="outlined" value={recipient}>
+                        </TextField>
+                        <Box m="0.5rem"/>
+                        <TextField
+                        InputProps={{startAdornment: <InputAdornment position="start">{`FIL`}</InputAdornment>}}
+                        onChange={handleAmountChange} size="medium" fullWidth id="recipient" label="Amount" variant="outlined" value={amount}>
+                        </TextField>
+                    </Grid>
+                </Grid>
+                <Box m="0.5rem"/>
+                <Grid container item xs={12} justify="flex-end">
+                    <Button onClick={onSign} color="secondary" variant="contained" size="large">SIGN</Button>
+                    <Box m="0.5rem"/>
+                    <Button onClick={onSubmit} color="secondary" variant="contained" size="large">SEND</Button>
+                </Grid>
+                <Snackbar
+                    open={alert}
+                    autoHideDuration={6000}
+                    onClose={() => setAlert(false)}
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                    }}>
+                    <Alert severity={severity} onClose={() => setAlert(false)}>
+                        {`${message} `}
+                    </Alert>
+                </Snackbar>
+            </CardContent>
+        </Card>
+    );
+};

--- a/packages/example/src/components/Transfer/Transfer.tsx
+++ b/packages/example/src/components/Transfer/Transfer.tsx
@@ -44,16 +44,10 @@ export const Transfer: React.FC<ITransferProps> = ({network, api}) => {
 
     const onSign = useCallback(async () => {
         if (amount && recipient && api) {
-            const address = await api.getAddress();
             // Temporary signature method until sending is implemented
             const signedMessage = await api.signMessage({
-                from: address,
                 to: recipient,
                 value: BigInt(amount).toString(),
-                method: 1,
-                gaslimit: 100,
-                gasprice: "0",
-                nonce: 1
             });
             showAlert("info", `Message signature: ${signedMessage.signature.data}`);
             setAmount("");

--- a/packages/example/src/components/Transfer/Transfer.tsx
+++ b/packages/example/src/components/Transfer/Transfer.tsx
@@ -56,6 +56,8 @@ export const Transfer: React.FC<ITransferProps> = ({network, api}) => {
                 nonce: 1
             });
             showAlert("info", `Message signature: ${signedMessage.signature.data}`);
+            setAmount("");
+            setRecipient("");
         }
     }, [amount, api, recipient]);
 

--- a/packages/example/src/containers/Dashboard/Dashboard.tsx
+++ b/packages/example/src/containers/Dashboard/Dashboard.tsx
@@ -9,6 +9,7 @@ import {Account} from "../../components/Account/Account";
 import {FilecoinSnapApi, Transaction} from "@nodefactory/metamask-filecoin-types";
 import {TransactionTable} from "../../components/TransactionTable/TransactionTable";
 import {SignMessage} from "../../components/SignMessage/SignMessage";
+import {Transfer} from "../../components/Transfer/Transfer";
 
 export const Dashboard = () => {
 
@@ -38,15 +39,6 @@ export const Dashboard = () => {
             if (state.filecoinSnap.isInstalled && state.filecoinSnap.snap) {
                 const filecoinApi = await state.filecoinSnap.snap.getFilecoinSnapApi();
                 setApi(filecoinApi);
-                await filecoinApi.signMessage({
-                    from: "t1hw4amnow4gsgk2ottjdpdverfwhaznyrslsmoni",
-                    to: "t12flyjpedjjqlrr2dmlnrtbh62qav3b3h7o7lohy",
-                    gaslimit: 10000,
-                    gasprice: "0",
-                    method: 1,
-                    nonce: 90571,
-                    value: "5000000000000000",
-                });
             }
         })();
     }, [state.filecoinSnap.isInstalled, state.filecoinSnap.snap]);
@@ -90,6 +82,9 @@ export const Dashboard = () => {
                     </Grid>
                     <Box m="1rem"/>
                     <Grid container spacing={3} alignItems="stretch">
+                        <Grid item md={6} xs={12}>
+                            <Transfer api={api} network={network} />
+                        </Grid>
                         <Grid item md={6} xs={12}>
                             <SignMessage api={api} />
                         </Grid>

--- a/packages/example/src/containers/Dashboard/Dashboard.tsx
+++ b/packages/example/src/containers/Dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import {MetaMaskContext} from "../../context/metamask";
 import {Account} from "../../components/Account/Account";
 import {FilecoinSnapApi, Transaction} from "@nodefactory/metamask-filecoin-types";
 import {TransactionTable} from "../../components/TransactionTable/TransactionTable";
+import {SignMessage} from "../../components/SignMessage/SignMessage";
 
 export const Dashboard = () => {
 
@@ -85,6 +86,12 @@ export const Dashboard = () => {
                     <Grid container spacing={3} alignItems="stretch">
                         <Grid item xs={12}>
                             <Account address={address} balance={balance + " FIL"} publicKey={publicKey} api={api}/>
+                        </Grid>
+                    </Grid>
+                    <Box m="1rem"/>
+                    <Grid container spacing={3} alignItems="stretch">
+                        <Grid item md={6} xs={12}>
+                            <SignMessage api={api} />
                         </Grid>
                     </Grid>
                     <Box m="1rem"/>

--- a/packages/example/src/containers/Dashboard/Dashboard.tsx
+++ b/packages/example/src/containers/Dashboard/Dashboard.tsx
@@ -37,6 +37,15 @@ export const Dashboard = () => {
             if (state.filecoinSnap.isInstalled && state.filecoinSnap.snap) {
                 const filecoinApi = await state.filecoinSnap.snap.getFilecoinSnapApi();
                 setApi(filecoinApi);
+                await filecoinApi.signMessage({
+                    from: "t1hw4amnow4gsgk2ottjdpdverfwhaznyrslsmoni",
+                    to: "t12flyjpedjjqlrr2dmlnrtbh62qav3b3h7o7lohy",
+                    gaslimit: 10000,
+                    gasprice: "0",
+                    method: 1,
+                    nonce: 90571,
+                    value: "5000000000000000",
+                });
             }
         })();
     }, [state.filecoinSnap.isInstalled, state.filecoinSnap.snap]);

--- a/packages/snap/@types/filecoin-signing-tools/index.d.ts
+++ b/packages/snap/@types/filecoin-signing-tools/index.d.ts
@@ -14,6 +14,11 @@ declare module "@zondax/filecoin-signing-tools/js" {
         get private_base64(): string;
     }
 
+    export interface PartialMessage {
+        to: string;
+        value: string;
+    }
+
     export interface Message {
         to: string;
         from: string;

--- a/packages/snap/@types/filecoin-signing-tools/index.d.ts
+++ b/packages/snap/@types/filecoin-signing-tools/index.d.ts
@@ -19,7 +19,7 @@ declare module "@zondax/filecoin-signing-tools/js" {
         from: string;
         nonce: number;
         value: string;
-        gasprice: string
+        gasprice: string;
         gaslimit: number;
         method: number;
         params?: any;

--- a/packages/snap/@types/filecoin-signing-tools/index.d.ts
+++ b/packages/snap/@types/filecoin-signing-tools/index.d.ts
@@ -14,11 +14,6 @@ declare module "@zondax/filecoin-signing-tools/js" {
         get private_base64(): string;
     }
 
-    export interface PartialMessage {
-        to: string;
-        value: string;
-    }
-
     export interface Message {
         to: string;
         from: string;

--- a/packages/snap/src/filecoin/types.ts
+++ b/packages/snap/src/filecoin/types.ts
@@ -1,6 +1,7 @@
 export interface LotusRpcApi {
   version(): Promise<VersionResponse>;
   walletBalance(address: string): Promise<string>;
+  mpoolGetNonce(address: string): Promise<string>;
 }
 
 type VersionResponse = { APIVersion: number; BlockDelay: number; Version: string };

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -10,15 +10,17 @@ import {showConfirmationDialog} from "../util/confirmation";
 import {LotusRpcApi} from "../filecoin/types";
 import {PartialMessage} from "@nodefactory/metamask-filecoin-types";
 
-export async function signMessage(wallet: Wallet, api: LotusRpcApi, partialMessage: PartialMessage): Promise<SignedMessage> {
+export async function signMessage(
+  wallet: Wallet, api: LotusRpcApi, partialMessage: PartialMessage
+): Promise<SignedMessage> {
   const keypair = await getKeyPair(wallet);
   const message: Message = {
     ...partialMessage,
     from: keypair.address,
-    nonce: Number(await api.mpoolGetNonce(keypair.address)),
-    gasprice: "5",  // TODO calculate from RPC method
     gaslimit: 10,   // TODO should be part of input form
-    method: 1       // TODO figure out method code for transaction
+    gasprice: "5",  // TODO calculate from RPC method
+    method: 1,       // TODO figure out method code for transaction
+    nonce: Number(await api.mpoolGetNonce(keypair.address))
   };
   const confirmation = await showConfirmationDialog(
     wallet,

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -23,13 +23,13 @@ export async function signMessage(wallet: Wallet, message: Message): Promise<Sig
 export async function signMessageRaw(wallet: Wallet, rawMessage: string): Promise<string> {
   const keypair = await getKeyPair(wallet);
   const confirmation = await showConfirmationDialog(
-      wallet,
-      `Do you want to sign message\n\n` +
+    wallet,
+    `Do you want to sign message\n\n` +
       `${rawMessage}\n\n`+
       `with account ${keypair.address}?`
   );
   if (confirmation) {
-      return transactionSignRaw(rawMessage, keypair.privateKey).toString("hex");
+    return transactionSignRaw(rawMessage, keypair.privateKey).toString("hex");
   }
   return null;
 }

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -1,6 +1,5 @@
 import {
   Message,
-  PartialMessage,
   SignedMessage,
   transactionSign,
   transactionSignRaw
@@ -9,6 +8,7 @@ import {Wallet} from "../interfaces";
 import {getKeyPair} from "../filecoin/account";
 import {showConfirmationDialog} from "../util/confirmation";
 import {LotusRpcApi} from "../filecoin/types";
+import {PartialMessage} from "@nodefactory/metamask-filecoin-types";
 
 export async function signMessage(wallet: Wallet, api: LotusRpcApi, partialMessage: PartialMessage): Promise<SignedMessage> {
   const keypair = await getKeyPair(wallet);

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -1,10 +1,25 @@
-import {Message, SignedMessage, transactionSign, transactionSignRaw} from "@zondax/filecoin-signing-tools/js";
+import {
+  Message,
+  PartialMessage,
+  SignedMessage,
+  transactionSign,
+  transactionSignRaw
+} from "@zondax/filecoin-signing-tools/js";
 import {Wallet} from "../interfaces";
 import {getKeyPair} from "../filecoin/account";
 import {showConfirmationDialog} from "../util/confirmation";
+import {LotusRpcApi} from "../filecoin/types";
 
-export async function signMessage(wallet: Wallet, message: Message): Promise<SignedMessage> {
+export async function signMessage(wallet: Wallet, api: LotusRpcApi, partialMessage: PartialMessage): Promise<SignedMessage> {
   const keypair = await getKeyPair(wallet);
+  const message: Message = {
+    ...partialMessage,
+    from: keypair.address,
+    nonce: Number(await api.mpoolGetNonce(keypair.address)),
+    gasprice: "5",  // TODO calculate from RPC method
+    gaslimit: 10,   // TODO should be part of input form
+    method: 1       // TODO figure out method code for transaction
+  };
   const confirmation = await showConfirmationDialog(
     wallet,
     `Do you want to sign message\n\n` +

--- a/packages/snap/src/rpc/signMessage.ts
+++ b/packages/snap/src/rpc/signMessage.ts
@@ -1,4 +1,4 @@
-import {Message, SignedMessage, transactionSign} from "@zondax/filecoin-signing-tools/js";
+import {Message, SignedMessage, transactionSign, transactionSignRaw} from "@zondax/filecoin-signing-tools/js";
 import {Wallet} from "../interfaces";
 import {getKeyPair} from "../filecoin/account";
 import {showConfirmationDialog} from "../util/confirmation";
@@ -16,6 +16,20 @@ export async function signMessage(wallet: Wallet, message: Message): Promise<Sig
   );
   if (confirmation) {
     return transactionSign(message, keypair.privateKey);
+  }
+  return null;
+}
+
+export async function signMessageRaw(wallet: Wallet, rawMessage: string): Promise<string> {
+  const keypair = await getKeyPair(wallet);
+  const confirmation = await showConfirmationDialog(
+      wallet,
+      `Do you want to sign message\n\n` +
+      `${rawMessage}\n\n`+
+      `with account ${keypair.address}?`
+  );
+  if (confirmation) {
+      return transactionSignRaw(rawMessage, keypair.privateKey).toString("hex");
   }
   return null;
 }

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -10,7 +10,7 @@ import {configure} from "./rpc/configure";
 import {updateAsset} from "./asset";
 import {getTransactions} from "./rpc/getTransactions";
 import {convertToFIL} from "./util/format";
-import {signMessage} from "./rpc/signMessage";
+import {signMessage, signMessageRaw} from "./rpc/signMessage";
 
 declare let wallet: Wallet;
 
@@ -56,6 +56,8 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
       return getTransactions(wallet);
     case "signMessage":
       return await signMessage(wallet, requestObject.params.message);
+    case "signMessageRaw":
+      return await signMessageRaw(wallet, requestObject.params.message);
     default:
       throw new Error("Unsupported RPC method");
   }

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -15,7 +15,7 @@ import {signMessage, signMessageRaw} from "./rpc/signMessage";
 declare let wallet: Wallet;
 
 const apiDependentMethods = [
-  "getBalance", "configure"
+  "getBalance", "configure", "signMessage"
 ];
 
 wallet.registerApiRequestHandler(async function (origin: URL): Promise<FilecoinEventApi> {
@@ -55,7 +55,7 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
     case "getTransactions":
       return getTransactions(wallet);
     case "signMessage":
-      return await signMessage(wallet, requestObject.params.message);
+      return await signMessage(wallet, api, requestObject.params.message);
     case "signMessageRaw":
       return await signMessageRaw(wallet, requestObject.params.message);
     default:

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -10,6 +10,7 @@ import {configure} from "./rpc/configure";
 import {updateAsset} from "./asset";
 import {getTransactions} from "./rpc/getTransactions";
 import {convertToFIL} from "./util/format";
+import {signMessage} from "./rpc/signMessage";
 
 declare let wallet: Wallet;
 
@@ -53,6 +54,8 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
       return balance;
     case "getTransactions":
       return getTransactions(wallet);
+    case "signMessage":
+      return await signMessage(wallet, requestObject.params.message);
     default:
       throw new Error("Unsupported RPC method");
   }

--- a/packages/snap/test/unit/rpc/getBalance.test.ts
+++ b/packages/snap/test/unit/rpc/getBalance.test.ts
@@ -20,7 +20,7 @@ describe('Test rpc handler function: getBalance', function() {
     // prepare stubs
     walletStub.getAppKey.returns(testAppKey);
     walletStub.getPluginState.returns(EmptyMetamaskState());
-    const apiStub = {walletBalance: sinon.stub(), version: sinon.stub()};
+    const apiStub = {walletBalance: sinon.stub(), version: sinon.stub(), mpoolGetNonce: sinon.stub()};
     apiStub.walletBalance.returns("3000000000000000000");
     // call getBalance
     const result = await getBalance(walletStub, apiStub);

--- a/packages/snap/test/unit/rpc/signMessage.test.ts
+++ b/packages/snap/test/unit/rpc/signMessage.test.ts
@@ -3,26 +3,39 @@ import chai, {expect} from "chai";
 import sinonChai from "sinon-chai";
 import {testAppKey} from "./keyPairTestConstants";
 import {SnapConfig} from "@nodefactory/metamask-filecoin-types";
-import {Message} from "@zondax/filecoin-signing-tools/js";
+import {Message, PartialMessage} from "@zondax/filecoin-signing-tools/js";
 import {signMessage} from "../../../src/rpc/signMessage";
+import sinon from "sinon";
 
 chai.use(sinonChai);
 
 describe('Test rpc handler function: signMessage', function () {
     const walletStub = new WalletMock();
+    const apiStub = {
+        walletBalance: sinon.stub(),
+        version: sinon.stub(),
+        mpoolGetNonce: sinon.stub()
+    };
 
-    const unsignedMessage: Message = {
-        from: "t1hw4amnow4gsgk2ottjdpdverfwhaznyrslsmoni",
+    const partialMessage: PartialMessage = {
         to: "t12flyjpedjjqlrr2dmlnrtbh62qav3b3h7o7lohy",
-        gaslimit: 10000,
-        gasprice: "0",
-        method: 1,
-        nonce: 90571,
         value: "5000000000000000",
+    };
+
+    const fullMessage: Message = {
+        ...partialMessage,
+        from: "f1rovwtiuo5ncslpmpjftzu5akswbgsgighjazxoi",
+        gaslimit: 10,
+        gasprice: "5",
+        method: 1,
+        nonce: 0
     };
 
     afterEach(function() {
         walletStub.reset();
+        apiStub.walletBalance.reset();
+        apiStub.mpoolGetNonce.reset();
+        apiStub.version.reset();
     });
 
     it('should successfully sign valid message on positive prompt', async function () {
@@ -31,12 +44,12 @@ describe('Test rpc handler function: signMessage', function () {
         walletStub.getPluginState.returns({
             filecoin: {config: {network: "f", derivationPath: "m/44'/461'/0/0/1"} as SnapConfig}
         });
-
-        const signedMessage = await signMessage(walletStub, unsignedMessage);
+        apiStub.mpoolGetNonce.returns("0");
+        const signedMessage = await signMessage(walletStub, apiStub, partialMessage);
         expect(walletStub.send).to.have.been.calledOnce;
         expect(walletStub.getPluginState).to.have.been.calledOnce;
         expect(walletStub.getAppKey).to.have.been.calledOnce;
-        expect(signedMessage.message).to.be.eq(unsignedMessage);
+        expect(signedMessage.message).to.be.deep.eq(fullMessage);
         expect(signedMessage.signature.data).to.not.be.empty;
         expect(signedMessage.signature.type).to.be.eq(1);
     });
@@ -47,8 +60,8 @@ describe('Test rpc handler function: signMessage', function () {
         walletStub.getPluginState.returns({
             filecoin: {config: {network: "f", derivationPath: "m/44'/461'/0/0/1"} as SnapConfig}
         });
-
-        const signedMessage = await signMessage(walletStub, unsignedMessage);
+        apiStub.mpoolGetNonce.returns("0");
+        const signedMessage = await signMessage(walletStub, apiStub, partialMessage);
         expect(walletStub.send).to.have.been.calledOnce;
         expect(walletStub.getPluginState).to.have.been.calledOnce;
         expect(walletStub.getAppKey).to.have.been.calledOnce;
@@ -62,11 +75,13 @@ describe('Test rpc handler function: signMessage', function () {
             filecoin: {config: {network: "f", derivationPath: "m/44'/461'/0/0/1"} as SnapConfig}
         });
 
-        const invalidMessage = unsignedMessage;
+        const invalidMessage = partialMessage;
         invalidMessage.value = "-5000000000000000";
 
+        apiStub.mpoolGetNonce.returns("0");
+
         expect(async () => {
-            return await signMessage(walletStub, invalidMessage);
+            return await signMessage(walletStub, apiStub, invalidMessage);
         }).to.throw;
     });
 });

--- a/packages/snap/test/unit/rpc/signMessage.test.ts
+++ b/packages/snap/test/unit/rpc/signMessage.test.ts
@@ -2,8 +2,8 @@ import {WalletMock} from "../wallet.mock.test";
 import chai, {expect} from "chai";
 import sinonChai from "sinon-chai";
 import {testAppKey} from "./keyPairTestConstants";
-import {SnapConfig} from "@nodefactory/metamask-filecoin-types";
-import {Message, PartialMessage} from "@zondax/filecoin-signing-tools/js";
+import {PartialMessage, SnapConfig} from "@nodefactory/metamask-filecoin-types";
+import {Message} from "@zondax/filecoin-signing-tools/js";
 import {signMessage} from "../../../src/rpc/signMessage";
 import sinon from "sinon";
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -24,6 +24,13 @@ export interface SignMessageRequest {
   };
 }
 
+export interface SignMessageRawRequest {
+  method: "signMessageRaw";
+  params: {
+    message: string;
+  };
+}
+
 export interface GetBalanceRequest {
   method: "getBalance";
 }
@@ -39,7 +46,8 @@ export type MetamaskFilecoinRpcRequest =
     ConfigureRequest |
     GetBalanceRequest |
     GetTransactionsRequest |
-    SignMessageRequest;
+    SignMessageRequest |
+    SignMessageRawRequest;
 
 type Method = MetamaskFilecoinRpcRequest["method"];
 
@@ -121,6 +129,7 @@ export interface FilecoinSnapApi {
   exportPrivateKey(): Promise<string>;
   configure(configuration: SnapConfig): Promise<void>;
   signMessage(message: Message): Promise<SignedMessage>;
+  signMessageRaw(message: string): Promise<string>;
 }
 
 export interface Transaction {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,5 +1,3 @@
-import {Message, SignedMessage} from "@zondax/filecoin-signing-tools/js";
-
 export interface GetPublicKeyRequest{
   method: "getPublicKey";
 }
@@ -65,6 +63,7 @@ export type BlockId = number|string|"latest";
 
 export interface TxPayload {
   tx: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload: any;
 }
 
@@ -90,6 +89,26 @@ export interface SnapConfig {
 export type Callback<T> = (arg: T) => void;
 
 // Filecoin types
+
+export interface Message {
+  to: string;
+  from: string;
+  nonce: number;
+  value: string;
+  gasprice: string;
+  gaslimit: number;
+  method: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params?: any;
+}
+
+export interface SignedMessage {
+  message: Message;
+  signature: {
+    data: string;
+    type: number;
+  };
+}
 
 export type FilecoinNetwork = "f" | "t";
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -20,7 +20,7 @@ export interface ConfigureRequest {
 export interface SignMessageRequest {
   method: "signMessage";
   params: {
-    message: Message;
+    message: PartialMessage;
   };
 }
 
@@ -116,6 +116,11 @@ export interface SignedMessage {
     data: string;
     type: number;
   };
+}
+
+export interface PartialMessage {
+  to: string;
+  value: string;
 }
 
 export type FilecoinNetwork = "f" | "t";

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,3 +1,5 @@
+import {Message, SignedMessage} from "@zondax/filecoin-signing-tools/js";
+
 export interface GetPublicKeyRequest{
   method: "getPublicKey";
 }
@@ -17,6 +19,13 @@ export interface ConfigureRequest {
   };
 }
 
+export interface SignMessageRequest {
+  method: "signMessage";
+  params: {
+    message: Message;
+  };
+}
+
 export interface GetBalanceRequest {
   method: "getBalance";
 }
@@ -31,7 +40,8 @@ export type MetamaskFilecoinRpcRequest =
     ExportSeedRequest |
     ConfigureRequest |
     GetBalanceRequest |
-    GetTransactionsRequest;
+    GetTransactionsRequest |
+    SignMessageRequest;
 
 type Method = MetamaskFilecoinRpcRequest["method"];
 
@@ -91,6 +101,7 @@ export interface FilecoinSnapApi {
   getBalance(): Promise<string>;
   exportPrivateKey(): Promise<string>;
   configure(configuration: SnapConfig): Promise<void>;
+  signMessage(message: Message): Promise<SignedMessage>;
 }
 
 export interface Transaction {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -133,7 +133,7 @@ export interface FilecoinSnapApi {
   getBalance(): Promise<string>;
   exportPrivateKey(): Promise<string>;
   configure(configuration: SnapConfig): Promise<void>;
-  signMessage(message: Message): Promise<SignedMessage>;
+  signMessage(message: PartialMessage): Promise<SignedMessage>;
   signMessageRaw(message: string): Promise<string>;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9982,6 +9982,13 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+normalize-hex@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/normalize-hex/-/normalize-hex-0.0.2.tgz#5491c43759db2f06b7168d8419f4925c271ab27e"
+  integrity sha512-E2dx7XJQnjsm6SkS4G6GGvIXRHaLeWAZE2D2N3aia+OpIif2UT8y4S0KCjrX3WmFDSeFnlNOp0FSHFjLeJ4SJw==
+  dependencies:
+    bn.js "^4.11.8"
+
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -13666,6 +13673,13 @@ to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+
+to-hex@^0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/to-hex/-/to-hex-0.0.15.tgz#a18f31f8f4cf8c7bd627cc25d7e58350b5f10e1f"
+  integrity sha512-sAMjdR0/do43JrvublqVeBL7IsxRICt3GksDJdx4biBQ1WZVoVuj2c+C8KQJ0BIG8AYs6oVAWPKW7lmXFrdILA==
+  dependencies:
+    normalize-hex "0.0.2"
 
 to-object-path@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Here I integrated **signing raw messages** and **signing transactions** (as a placeholder until #26 is finished).

closes #24 

---

Signing raw messages, for provided raw message calculates and display signature (_RPC method **signMessageRaw**_):

![filecoin-sign-raw](https://user-images.githubusercontent.com/23664028/88049208-054fdc80-cb55-11ea-9771-4352783b586d.gif)


Signing transactions (_RPC method **signMessage**_), there is still some work on determining `gasLimit` and `gasPrice`. @mpetrunic I guess these properties should be part of the input form for creating transaction (maybe auto-filled with some predefined/calculated values). Maybe I can move this to separate PR?  :

![filecoin-sign-message](https://user-images.githubusercontent.com/23664028/88049275-24e70500-cb55-11ea-8ebd-dbdc332cf05d.gif)

