### PR TITLE
Snap custom configuration

### DIFF
--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -9,17 +9,19 @@ export type MetamaskFilecoinSnap = MFSnap;
 
 export {hasMetaMask, isMetamaskSnapsSupported} from "./utils";
 
-export async function enableFilecoinSnap(config: Partial<SnapConfig>, pluginOrigin?: string): Promise<MetamaskFilecoinSnap> {
+export async function enableFilecoinSnap(
+  config: Partial<SnapConfig>, pluginOrigin?: string
+): Promise<MetamaskFilecoinSnap> {
+
+  // check all conditions
   if (!hasMetaMask()) {
     throw new Error("Metamask is not installed");
   }
-
   if (!await isMetamaskSnapsSupported()) {
     throw new Error("Current Metamask version doesn't support snaps");
   }
-
   if (!config.network) {
-      throw new Error("Configuration must at least define network type");
+    throw new Error("Configuration must at least define network type");
   }
 
   // enable snap

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,5 +1,6 @@
 import {hasMetaMask, isMetamaskSnapsSupported, isSnapInstalled} from "./utils";
 import {MetamaskFilecoinSnap as MFSnap} from "./snap";
+import {SnapConfig} from "@nodefactory/metamask-filecoin-types";
 
 const defaultSnapOrigin = "http://localhost:8081/package.json";
 const defaultSnapId = `wallet_plugin_${defaultSnapOrigin}`;
@@ -8,13 +9,17 @@ export type MetamaskFilecoinSnap = MFSnap;
 
 export {hasMetaMask, isMetamaskSnapsSupported} from "./utils";
 
-export async function enableFilecoinSnap(network: "f"|"t", pluginOrigin?: string): Promise<MetamaskFilecoinSnap> {
+export async function enableFilecoinSnap(config: Partial<SnapConfig>, pluginOrigin?: string): Promise<MetamaskFilecoinSnap> {
   if (!hasMetaMask()) {
     throw new Error("Metamask is not installed");
   }
 
   if (!await isMetamaskSnapsSupported()) {
     throw new Error("Current Metamask version doesn't support snaps");
+  }
+
+  if (!config.network) {
+      throw new Error("Configuration must at least define network type");
   }
 
   // enable snap
@@ -32,7 +37,7 @@ export async function enableFilecoinSnap(network: "f"|"t", pluginOrigin?: string
     pluginOrigin || defaultSnapOrigin
   );
   // set initial configuration
-  await (await snap.getFilecoinSnapApi()).configure({network});
+  await (await snap.getFilecoinSnapApi()).configure(config);
   // return snap object
   return snap;
 }

--- a/packages/example/src/services/metamask.ts
+++ b/packages/example/src/services/metamask.ts
@@ -28,7 +28,7 @@ export async function installFilecoinSnap(): Promise<SnapInitializationResponse>
     try {
         console.log("installing snap");
         // enable filecoin snap with default testnet network
-        const metamaskFilecoinSnap = await enableFilecoinSnap("t");
+        const metamaskFilecoinSnap = await enableFilecoinSnap({network: "t"});
         isInstalled = true;
         console.log("Snap installed!!");
         return {isSnapInstalled: true, snap: metamaskFilecoinSnap};


### PR DESCRIPTION
Enables providing full or partial configuration object on snap initialization through the `adapter`.

closes #35